### PR TITLE
Update stp_bpdu_conf.py

### DIFF
--- a/pyersinia_lib/libs/plugins/stp_bdpu_conf.py
+++ b/pyersinia_lib/libs/plugins/stp_bdpu_conf.py
@@ -23,10 +23,10 @@ def run(inter):
                 # Root Identifier 8 bytes (MAC and root priority)
 
                 srcMAC = str(RandMAC())     # Random MAC in each iteration
-                root_prior = RandInt() % 65536  # 2 bytes
+                root_prior = int(RandInt()) % 65536  # 2 bytes
 
                 # Brigde Identifier (mac and brigde priority)
-                brigde_prior = RandInt() % 65536  # 2 bytes
+                brigde_prior = int(RandInt()) % 65536  # 2 bytes
 
                 # dst=Ethernet Multicast address used for spanning tree protocol
                 p_ether = Dot3(dst="01:80:c2:00:00:00", src=srcMAC)


### PR DESCRIPTION
The RandInt() method returns <RandInt> not int. It should be casted firstly.